### PR TITLE
arm64: dts: renesas: kakip-es1: remove sdr50 property from sdhi0

### DIFF
--- a/arch/arm64/boot/dts/renesas/kakip-es1.dts
+++ b/arch/arm64/boot/dts/renesas/kakip-es1.dts
@@ -306,7 +306,6 @@
 	vqmmc-supply = <&vccq_sdhi0>;
 	non-removable;
 	bus-width = <4>;
-	sd-uhs-sdr50;
 	status = "okay";
 };
 


### PR DESCRIPTION
According to the feedback, it will cause compatibility concern for some uSD card, so take out the fixed sdr50 property is more safety.

Reported-by: M.Kawakami <github_amt_nsk@amatama.co>