### PR TITLE
arm64: dts: renesas: kakip-es1: add STB pin definition for canfd bus

### DIFF
--- a/arch/arm64/boot/dts/renesas/kakip-es1.dts
+++ b/arch/arm64/boot/dts/renesas/kakip-es1.dts
@@ -194,9 +194,23 @@
 			 <RZG2L_PORT_PINMUX(8, 1, 5)>; /* RX */
 	};
 
+	can0_stb {
+		gpio-hog;
+		gpios = <RZG2L_GPIO(10, 2) GPIO_ACTIVE_LOW>;
+		output-high;
+		line-name = "can0_stb";
+	};
+
 	can3_pins: can3 {
 		pinmux = <RZG2L_PORT_PINMUX(8, 6, 5)>, /* TX */
 			 <RZG2L_PORT_PINMUX(8, 7, 5)>; /* RX */
+	};
+
+	can3_stb {
+		gpio-hog;
+		gpios = <RZG2L_GPIO(10, 3) GPIO_ACTIVE_LOW>;
+		output-high;
+		line-name = "can3_stb";
 	};
 
 	scif0_pins: scif0 {
@@ -213,13 +227,6 @@
 		gpios = <RZG2L_GPIO(10, 1) GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "sd0_pwr_en";
-	};
-
-	sd1_pwr_en {
-		gpio-hog;
-		gpios = <RZG2L_GPIO(10, 3) GPIO_ACTIVE_HIGH>;
-		output-high;
-		line-name = "sd1_pwr_en";
 	};
 
 	i2c0_pins: i2c0 {


### PR DESCRIPTION
Can bus communication will failed without STB (standby) pin definition

Initial canfd and test communication commands on user-space as follows:
    # sudo ip link set can0 type can bitrate 125000 dbitrate 200000 fd on
    # sudo ifconfig can0 up
    # sudo ip link set can1 type can bitrate 125000 dbitrate 200000 fd on
    # sudo ifconfig can1 up
    # candump can0 &
    # cansend can1 333##1DEADBEEFDEADBEEFDEADBEEFDEADBEEF

The following result show on the sonsole:

    can0  333  [16]  DE AD BE EF DE AD BE EF DE AD BE EF DE AD BE EF

This confirms successful communication between can1 and can0